### PR TITLE
Fixed ClubCreationService, added to Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><a href="#" target="_blank"><img src="https://github.com/ccy7701/UMSSAC_SYSTEM/blob/main/public/images/UMSSACS_LOGO_FINAL.png" width="300" alt="UMSSACS Logo"></a></p>
 
-## Current Status ![Version](https://img.shields.io/badge/version-0.9.3--alpha-blue)
+## Current Status ![Version](https://img.shields.io/badge/version-0.9.4--alpha-blue)
 
 This project is still under active development. A preview of the system has been deployed. It is now live and accessible at [this link](https://umssacs.my).
 

--- a/app/Services/ClubCreationService.php
+++ b/app/Services/ClubCreationService.php
@@ -114,8 +114,8 @@ class ClubCreationService
             $query = ClubCreationRequest::with(['profile.account'])->where('request_status', $requestStatus);
         }
 
-        // If the account is not admin, restrict the query to match the current profile's profile_id
-        if (currentAccount()->account_role !== 3) {
+        // If the account is FacultyMember, add to the query to match the current profile's profile ID
+        if (currentAccount()->account_role == 2) {
             $query = $query->where('requester_profile_id', profile()->profile_id);
         }
     

--- a/app/Services/ClubMembershipService.php
+++ b/app/Services/ClubMembershipService.php
@@ -147,7 +147,8 @@ class ClubMembershipService
             'new_membership_type' => 'required|integer',
         ]);
 
-        $status = DB::table('club_membership')
+        // Update the membership_type
+        DB::table('club_membership')
             ->where('profile_id', $validatedData['profile_id'])
             ->where('club_id', $validatedData['club_id'])
             ->update([
@@ -160,6 +161,9 @@ class ClubMembershipService
         } else {
             $route = route('admin-manage.edit-member-access', ['club_id' => $validatedData['club_id']]);
         }
+
+        // Then, create a Notification to send to the club member
+        $status = $this->notificationService->prepareMemberAccessUpdateNotification($validatedData);
 
         return $status
             ? redirect($route)->with('success', 'Member access level updated successfully.')

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use App\Models\Account;
 use App\Models\Profile;
 use App\Models\Notification;
+use App\Models\Club;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\ClubCreationRequestNotification;
@@ -172,7 +173,7 @@ class NotificationService
     }
 
     /**
-     * Hande sending a join club acceptance notification (Notification::class)
+     * Handle sending a join club acceptance notification (Notification::class)
      * to the user who made the request.
      *
      * @param \App\Models\ClubMembership $clubMembership
@@ -193,6 +194,39 @@ class NotificationService
         Notification::create($notificationData);
 
         return 'Join acceptance notification created successfully';
+    }
+
+    /**
+     * Handle sending a club member access update notification to the user.
+     *
+     * @param array $newMembershipData
+     */
+    public function prepareMemberAccessUpdateNotification($newMembershipData) {
+        // dd($updateData);
+        $notificationMessage = null;
+
+        $club = Club::where('club_id', $newMembershipData['club_id'])->first();
+
+        // Prepare the notification title and message based on the new membership type
+        if ($newMembershipData['new_membership_type'] == 1) {
+            $notificationMessage = "You are no longer a committee member of the club: " . $club->club_name . "."; 
+        } elseif ($newMembershipData['new_membership_type'] == 2) {
+            $notificationMessage = "Congratulations! You are now a committee member of the club: " . $club->club_name . ".";
+        }
+
+        // Create the notification content
+        $notificationData = [
+            'profile_id' => $newMembershipData['profile_id'],
+            'notification_type' => 'club_membership_update',
+            'notification_title' => 'Club Membership Update',
+            'notification_message' => $notificationMessage,
+            'is_read' => 0,
+        ];
+
+        // Create the Notification object
+        Notification::create($notificationData);
+
+        return 'Club membership update notification created successfully';
     }
 
     /**

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -202,14 +202,13 @@ class NotificationService
      * @param array $newMembershipData
      */
     public function prepareMemberAccessUpdateNotification($newMembershipData) {
-        // dd($updateData);
         $notificationMessage = null;
 
         $club = Club::where('club_id', $newMembershipData['club_id'])->first();
 
         // Prepare the notification title and message based on the new membership type
         if ($newMembershipData['new_membership_type'] == 1) {
-            $notificationMessage = "You are no longer a committee member of the club: " . $club->club_name . "."; 
+            $notificationMessage = "You are no longer a committee member of the club: " . $club->club_name . ".";
         } elseif ($newMembershipData['new_membership_type'] == 2) {
             $notificationMessage = "Congratulations! You are now a committee member of the club: " . $club->club_name . ".";
         }

--- a/resources/views/components/admin-topnav.blade.php
+++ b/resources/views/components/admin-topnav.blade.php
@@ -24,7 +24,7 @@
 <!-- Offcanvas Navbar for Notification -->
 <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvas-notifications-bar" aria-labelledby="offcanvas-notifications-bar-label">
     <div class="rsans offcanvas-header pb-0">
-        <h5 class="offcanvas-title" id="offcanvas-notifications-bar-label">Notifications (WIP)</h5>
+        <h5 class="offcanvas-title" id="offcanvas-notifications-bar-label">Notifications</h5>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <hr class="divider-gray-300 py-0 mt-3 mb-0">

--- a/resources/views/components/topnav.blade.php
+++ b/resources/views/components/topnav.blade.php
@@ -25,7 +25,7 @@
 <!-- Offcanvas Navbar for Notifications -->
 <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvas-notifications-bar" aria-labelledby="offcanvas-notifications-bar-label">
     <div class="rsans offcanvas-header pb-0">
-        <h5 class="offcanvas-title" id="offcanvas-notifications-bar-label">Notifications (WIP)</h5>
+        <h5 class="offcanvas-title" id="offcanvas-notifications-bar-label">Notifications</h5>
         <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <hr class="divider-gray-300 py-0 mt-3 mb-0">

--- a/storage/changelog.json
+++ b/storage/changelog.json
@@ -1,5 +1,12 @@
 [
     {
+        "version": "0.9.4-alpha",
+        "changes": [
+            "Fixed an issue where the admin was not able to view all club creation requests in the overview page.",
+            "Extended notifications tab functionality to show club membership updates."
+        ]
+    },
+    {
         "version": "0.9.3-alpha",
         "changes": [
             "Extended notifications tab functionality to show club creation request status."


### PR DESCRIPTION
1. Fixed an issue where the admin was not able to view all club creation requests in the overview page.
2. Added to Notifications bar: a user is now notified if their club membership type for any club they're in is updated.